### PR TITLE
Don't declare hashie gem as a dependency

### DIFF
--- a/transifex.gemspec
+++ b/transifex.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 0.9.1'
   spec.add_dependency 'faraday_middleware', '~> 0.10.0'
-  spec.add_dependency 'hashie', '~> 3.4'
 
   spec.add_development_dependency "bundler", "~> 1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'rspec', '~> 3'       #, '~> 2.0'
   spec.add_development_dependency 'guard', '~> 2'
   spec.add_development_dependency 'guard-rspec', '~> 4'
+  spec.add_development_dependency 'hashie', '~> 3.4'
 end


### PR DESCRIPTION
Moves hashie gem to a development dependency.